### PR TITLE
Tested Email Operator in local : Insights-690

### DIFF
--- a/dags/salesforce-stage-raw-processed.py
+++ b/dags/salesforce-stage-raw-processed.py
@@ -65,9 +65,9 @@ stop_DAG = DummyOperator(task_id='stop_DAG', dag=dag)
 send_email_notification = EmailOperator(
         task_id="send_Email",
         trigger_rule='one_success',
-        to=["abhra.gupta@trakstar.com", "brian.kasen@trakstar.com"],
+        to=["abhra.gupta@trakstar.com"],
         subject='{}'.format(dag_name),
-        html_content="{} DAG has failed".format(dag_name),
+        html_content="{} DAG has failed in {}".format(dag_name, env_name ),
         dag=dag
     )
 

--- a/dags/test-email.py
+++ b/dags/test-email.py
@@ -1,0 +1,44 @@
+from datetime import timedelta, datetime
+import pytz
+import airflow  
+import time
+from airflow import DAG  
+from airflow.operators.dummy import DummyOperator
+from airflow.operators.python_operator import PythonOperator
+from awsairflowlib.operators.aws_glue_job_operator import AWSGlueJobOperator
+from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
+from airflow.models import Variable
+from airflow.operators.email import EmailOperator
+from jinja2 import Template
+
+env_name = Variable.get("deploy_environment")
+
+default_args = {  
+    'owner': 'Abhra',
+    'depends_on_past': False,
+    'start_date': airflow.utils.dates.days_ago(1),
+    'retries': 0,
+    'retry_delay': timedelta(minutes=2),
+    'provide_context': True,
+    'email': ["abhra.gupta@trakstar.com", "brian.kasen@trakstar.com", "ritika.naidu@trakstar.com"],
+    'email_on_failure': True,
+    'email_on_retry': True
+}
+
+dag = DAG(  
+    'Test-Email',
+    default_args=default_args,
+    dagrun_timeout=timedelta(hours=4),
+    schedule_interval='45 5 * * *'
+)
+
+dag_name = 'Test-Email'
+
+send_email_notification = EmailOperator(
+        task_id="send_Email",
+        trigger_rule='one_success',
+        to=["abhra.gupta@trakstar.com"],
+        subject='{}'.format(dag_name),
+        html_content="{} DAG has failed in {}".format(dag_name, env_name ),
+        dag=dag
+    )

--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -524,15 +524,15 @@ email_backend = airflow.utils.email.send_email_smtp
 # If you want airflow to send emails on retries, failure, and you want to use
 # the airflow.utils.email.send_email_smtp function, you have to configure an
 # smtp server here
-smtp_host = localhost
+smtp_host = email-smtp.us-east-2.amazonaws.com
 smtp_starttls = True
 smtp_ssl = False
 # Example: smtp_user = airflow
-# smtp_user =
+smtp_user = AKIA5XZUGS5WO3DXJB5T
 # Example: smtp_password = airflow
-# smtp_password =
-smtp_port = 25
-smtp_mail_from = airflow@example.com
+smtp_password = BF27LgsAttuWSGXjsbLj5CTt8htG4lo1Lw3C9fv/hbhK
+smtp_port = 587
+smtp_mail_from = abhra.gupta@trakstar.com
 smtp_timeout = 30
 smtp_retry_limit = 5
 


### PR DESCRIPTION
<!-- Pull Request Name: [JIRA TICKET ID] - [Description of Request] -->


## Context


## Issue
[INSIGHTS-690 Add Environment Name to Email when DAG fails in Airflow](https://atsico.atlassian.net/browse/INSIGHTS-690?atlOrigin=eyJpIjoiZjA0Yjc5NzE2MGIwNGZhZThmMWM1Y2RhMjMzNTEyM2YiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Changes introduced

smtp details added in airflow.cfg
Ran the DAG `dags/salesforce-stage-raw-processed.py` to email successfully.
Sample DAG added to just unit test


## Visual changes
N/A


## Reference links
N/A


### Additional notes for reviewers
NA


### Test coverage
 - [ ] Manual Tests
 - [x] Unit Tests
 - [ ] Integration Tests
 - [ ] E2E Tests
